### PR TITLE
Fix text selection bug in editor

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -63,4 +63,20 @@
 	.prose ::selection {
 		@apply bg-branch-accent/20;
 	}
+
+	/* Enable text selection in Editor component when in edit mode */
+	.ProseMirror {
+		user-select: text !important;
+		-webkit-user-select: text !important;
+		-moz-user-select: text !important;
+		-ms-user-select: text !important;
+	}
+
+	/* Also enable text selection for any contenteditable elements */
+	[contenteditable="true"] {
+		user-select: text !important;
+		-webkit-user-select: text !important;
+		-moz-user-select: text !important;
+		-ms-user-select: text !important;
+	}
 }


### PR DESCRIPTION
Enable text selection within the Editor component to fix broken editing functionality.

The global `user-select: none` CSS applied to the `body` element disabled text selection across the application, which negatively impacted content editing within the Editor component when in 'edit' mode.